### PR TITLE
#36 계정 이메일, 이름 대소문자 구별하지 않도록 수정 : 계정 생성 시 소문자로 저장하고 검색 시 대소문자 구별하지 않도…

### DIFF
--- a/src/main/java/com/posty/postingapi/domain/account/AccountRepositoryImpl.java
+++ b/src/main/java/com/posty/postingapi/domain/account/AccountRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.posty.postingapi.domain.account;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -24,7 +23,7 @@ public class AccountRepositoryImpl implements AccountRepositoryCustom {
                 .selectOne()
                 .from(qAccount)
                 .where(
-                        qAccount.email.eq(email),
+                        qAccount.email.lower().eq(email.toLowerCase()),
                         qAccount.status.ne(AccountStatus.DELETED)
                 )
                 .fetchFirst() != null;
@@ -38,7 +37,7 @@ public class AccountRepositoryImpl implements AccountRepositoryCustom {
                 .selectOne()
                 .from(qAccount)
                 .where(
-                        qAccount.name.eq(name),
+                        qAccount.name.lower().eq(name.toLowerCase()),
                         qAccount.status.ne(AccountStatus.DELETED)
                 )
                 .fetchFirst() != null;
@@ -51,7 +50,7 @@ public class AccountRepositoryImpl implements AccountRepositoryCustom {
         Account account = queryFactory
                 .selectFrom(qAccount)
                 .where(
-                        qAccount.email.eq(email),
+                        qAccount.email.lower().eq(email.toLowerCase()),
                         qAccount.status.ne(AccountStatus.DELETED)
                 )
                 .fetchOne();

--- a/src/main/java/com/posty/postingapi/dto/AccountCreateRequest.java
+++ b/src/main/java/com/posty/postingapi/dto/AccountCreateRequest.java
@@ -26,4 +26,14 @@ public class AccountCreateRequest {
     private String name;
 
     private String mobileNumber;
+
+    public void normalize() {
+        if (this.email != null) {
+            this.email = this.email.trim().toLowerCase();
+        }
+
+        if (this.name != null) {
+            this.name = this.name.trim().toLowerCase();
+        }
+    }
 }

--- a/src/main/java/com/posty/postingapi/security/SecurityConfig.java
+++ b/src/main/java/com/posty/postingapi/security/SecurityConfig.java
@@ -2,11 +2,11 @@ package com.posty.postingapi.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 public class SecurityConfig {
@@ -15,6 +15,11 @@ public class SecurityConfig {
 
     public SecurityConfig(ApiKeyFilter apiKeyFilter) {
         this.apiKeyFilter = apiKeyFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/resources/log4j2-live.xml
+++ b/src/main/resources/log4j2-live.xml
@@ -36,5 +36,8 @@
         <!-- RMI 관련 로그 설정 -->
         <Logger name="sun.rmi" level="ERROR" additivity="false"/>
         <Logger name="javax.management.remote.rmi" level="ERROR" additivity="false"/>
+
+        <!-- HikariCP 로그 설정 -->
+        <Logger name="com.zaxxer.hikari" level="INFO" additivity="false"/>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2-local.xml
+++ b/src/main/resources/log4j2-local.xml
@@ -19,5 +19,8 @@
         <!-- RMI 관련 로그 설정 -->
         <Logger name="sun.rmi" level="ERROR" additivity="false"/>
         <Logger name="javax.management.remote.rmi" level="ERROR" additivity="false"/>
+
+        <!-- HikariCP 로그 설정 -->
+        <Logger name="com.zaxxer.hikari" level="INFO" additivity="false"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
…록 수정, 엔티티로 변환 시 암호 처리는 서비스 로직에서 수행하도록 수정, 암호 처리 방식 개선, 사용하지 않는 코드 제거, 불필요하게 계속 찍히는 로그 안 보이도록 설정